### PR TITLE
[quant-proto] T1.4 Execution Constraints & Trade Guards

### DIFF
--- a/quant-proto/README.md
+++ b/quant-proto/README.md
@@ -87,6 +87,30 @@ Given daily NAV series `NAV_t` and daily return `r_t = NAV_t / NAV_{t-1} - 1`:
 
 Short sample policy: when sample length is `<20` trading days, `Volatility(ann)` and `Sharpe(rf=0)` degrade to `0.0` to avoid unstable estimates.
 
+
+Execution constraints (T1.4, backward-compatible defaults):
+
+```bash
+python -m quant_proto backtest \
+  --start 2022-01-01 --end 2022-12-31 \
+  --min-trade-notional 0 \
+  --lot-size 1 \
+  --max-daily-turnover 1.0 \
+  --gap-block-threshold 1.0
+```
+
+- `min_trade_notional`: minimum per-order notional to allow an order (default `0`, disabled)
+- `lot_size`: order/fill share lot granularity (default `1`)
+- `max_daily_turnover`: cap on `today BUY notional / prev-day NAV` in `[0,1]` (default `1.0`)
+- `gap_block_threshold`: if `abs(next_open/close - 1)` is greater than threshold, block new BUY open (default `1.0`)
+
+`orders.csv`/`fills.csv` reasons include:
+- `rebalance`
+- `below_min_notional`
+- `rounded_lot`
+- `blocked_turnover`
+- `blocked_gap`
+
 ## Output artifacts
 
 Each run writes to:

--- a/quant-proto/quant_proto/__main__.py
+++ b/quant-proto/quant_proto/__main__.py
@@ -29,6 +29,10 @@ def build_parser() -> argparse.ArgumentParser:
         sp.add_argument("--initial-cash", type=float, default=100_000.0)
         sp.add_argument("--slippage-bps", type=float, default=5.0)
         sp.add_argument("--commission-bps", type=float, default=1.0)
+        sp.add_argument("--min-trade-notional", type=float, default=0.0)
+        sp.add_argument("--lot-size", type=int, default=1)
+        sp.add_argument("--max-daily-turnover", type=float, default=1.0)
+        sp.add_argument("--gap-block-threshold", type=float, default=1.0)
         sp.add_argument("--force-refresh-data", action="store_true")
 
     bt = sub.add_parser("backtest", help="Run backtest and write artifacts to runs/")
@@ -71,16 +75,24 @@ def main(argv: List[str] | None = None) -> None:
                 slippage_bps=float(args.slippage_bps),
                 commission_bps=float(args.commission_bps),
                 t_plus_1=True,
+                min_trade_notional=float(args.min_trade_notional),
+                lot_size=int(args.lot_size),
+                max_daily_turnover=float(args.max_daily_turnover),
+                gap_block_threshold=float(args.gap_block_threshold),
             ),
             risk=cfg.risk,
         )
 
-        run_dir = run_sim(
-            cfg=cfg,
-            mode=args.cmd,
-            run_base_dir=Path("runs"),
-            force_refresh_data=bool(args.force_refresh_data),
-        )
+        try:
+            run_dir = run_sim(
+                cfg=cfg,
+                mode=args.cmd,
+                run_base_dir=Path("runs"),
+                force_refresh_data=bool(args.force_refresh_data),
+            )
+        except ValueError as exc:
+            print(str(exc), file=__import__("sys").stderr)
+            raise SystemExit(2)
         rep, _ = load_report(run_dir=run_dir)
         print(f"Run dir: {run_dir}")
         print(format_report(rep))

--- a/quant-proto/quant_proto/core/broker.py
+++ b/quant-proto/quant_proto/core/broker.py
@@ -80,6 +80,10 @@ class BrokerConfig:
     slippage_bps: float = 5.0
     commission_bps: float = 1.0
     t_plus_1: bool = True
+    min_trade_notional: float = 0.0
+    lot_size: int = 1
+    max_daily_turnover: float = 1.0
+    gap_block_threshold: float = 1.0
 
 
 @dataclass

--- a/quant-proto/quant_proto/core/sim.py
+++ b/quant-proto/quant_proto/core/sim.py
@@ -49,6 +49,17 @@ class RiskState:
     exposure_factor: float = 1.0
 
 
+def _validate_exec_constraints(cfg: SimConfig) -> None:
+    if cfg.broker.lot_size <= 0:
+        raise ValueError(f"invalid broker.lot_size={cfg.broker.lot_size}; must be > 0")
+    if cfg.broker.min_trade_notional < 0:
+        raise ValueError(f"invalid broker.min_trade_notional={cfg.broker.min_trade_notional}; must be >= 0")
+    if cfg.broker.max_daily_turnover < 0 or cfg.broker.max_daily_turnover > 1:
+        raise ValueError(f"invalid broker.max_daily_turnover={cfg.broker.max_daily_turnover}; must be in [0,1]")
+    if cfg.broker.gap_block_threshold < 0:
+        raise ValueError(f"invalid broker.gap_block_threshold={cfg.broker.gap_block_threshold}; must be >= 0")
+
+
 def _make_run_dir(base: Path) -> Path:
     ts = datetime.now().strftime("%Y-%m-%d-%H%M%S")
     run_dir = base / ts
@@ -208,6 +219,7 @@ def run_sim(
 
     mode: 'backtest' or 'paper' (same engine; paper emphasizes artifacts).
     """
+    _validate_exec_constraints(cfg)
     run_dir = _make_run_dir(run_base_dir)
 
     # Universe snapshot as-of start date
@@ -363,15 +375,96 @@ def run_sim(
             audit["exec_day"] = fmt_yyyy_mm_dd(next_day)
             sizing_log.append(audit)
 
-        # Build orders from current -> target
+        # Build orders from current -> target with execution constraints (T1.4)
         orders_next: List[Order] = []
+        lot = int(cfg.broker.lot_size)
+        min_notional = float(cfg.broker.min_trade_notional)
+        max_turnover = float(cfg.broker.max_daily_turnover)
+        gap_th = float(cfg.broker.gap_block_threshold)
+
+        # 1) Sells first (always allowed for reduce/close), lot/min-notional constrained
         for sym in cfg.universe:
             cur = broker.state.position_qty(sym)
             tgt = target_qty.get(sym, 0)
-            if tgt < cur:
-                orders_next.append(Order(day=next_day, symbol=sym, side="SELL", qty=cur - tgt, reason="rebalance"))
-            elif tgt > cur:
-                orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=tgt - cur, reason="rebalance"))
+            if tgt >= cur:
+                continue
+            qty = cur - tgt
+            if lot > 1:
+                q2 = (qty // lot) * lot
+                if q2 != qty:
+                    if q2 > 0:
+                        orders_next.append(Order(day=next_day, symbol=sym, side="SELL", qty=q2, reason="rounded_lot"))
+                    else:
+                        orders_next.append(Order(day=next_day, symbol=sym, side="SELL", qty=0, reason="below_min_notional"))
+                    qty = q2
+            if qty > 0:
+                exp_px = float(market.iloc[idx + 1][f"{sym}_Open"]) * (1.0 - bps(cfg.broker.slippage_bps))
+                if qty * exp_px < min_notional:
+                    orders_next.append(Order(day=next_day, symbol=sym, side="SELL", qty=0, reason="below_min_notional"))
+                else:
+                    orders_next.append(Order(day=next_day, symbol=sym, side="SELL", qty=qty, reason="rebalance"))
+
+        # 2) Buys with gap block, lot sizing, min notional, and max daily turnover cap
+        # turnover budget based on today's NAV (prev day for execution day)
+        turnover_budget = nav * max_turnover
+        used_buy_notional = 0.0
+        buy_syms = [sym for sym in cfg.universe if target_qty.get(sym, 0) > broker.state.position_qty(sym)]
+        for sym in sorted(buy_syms):
+            cur = broker.state.position_qty(sym)
+            raw_qty = target_qty.get(sym, 0) - cur
+            if raw_qty <= 0:
+                continue
+
+            close_px = close_prices[sym]
+            next_open_px = float(market.iloc[idx + 1][f"{sym}_Open"])
+            gap = abs(next_open_px / close_px - 1.0) if close_px > 0 else 0.0
+            if gap > gap_th:
+                orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=0, reason="blocked_gap"))
+                continue
+
+            qty = raw_qty
+            reason = "rebalance"
+
+            if lot > 1:
+                q2 = (qty // lot) * lot
+                if q2 != qty:
+                    reason = "rounded_lot" if q2 > 0 else "below_min_notional"
+                qty = q2
+            if qty <= 0:
+                orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=0, reason=reason))
+                continue
+
+            exp_buy_px = next_open_px * (1.0 + bps(cfg.broker.slippage_bps))
+            est_notional = qty * exp_buy_px
+            if est_notional < min_notional:
+                orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=0, reason="below_min_notional"))
+                continue
+
+            remain_budget = turnover_budget - used_buy_notional
+            if remain_budget < -1e-9:
+                remain_budget = 0.0
+            max_qty_turnover = int((remain_budget + 1e-9) // exp_buy_px) if exp_buy_px > 0 else 0
+            if qty > max_qty_turnover:
+                qty = max_qty_turnover
+                reason = "blocked_turnover"
+
+            if lot > 1:
+                q3 = (qty // lot) * lot
+                if q3 != qty:
+                    reason = "rounded_lot" if q3 > 0 else "blocked_turnover"
+                qty = q3
+
+            if qty <= 0:
+                orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=0, reason="blocked_turnover"))
+                continue
+
+            est_notional = qty * exp_buy_px
+            if est_notional < min_notional:
+                orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=0, reason="below_min_notional"))
+                continue
+
+            used_buy_notional += est_notional
+            orders_next.append(Order(day=next_day, symbol=sym, side="BUY", qty=qty, reason=reason))
 
         pending_orders[next_day] = orders_next
 

--- a/quant-proto/tests/test_execution_constraints.py
+++ b/quant-proto/tests/test_execution_constraints.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import csv
+import subprocess
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from quant_proto.core.broker import BrokerConfig
+from quant_proto.core.sim import SimConfig, run_sim
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "data"
+
+
+class ExecutionConstraintsTests(unittest.TestCase):
+    def _run(self, broker: BrokerConfig, initial_cash: float = 100_000.0) -> Path:
+        td = tempfile.mkdtemp(prefix="qp_t14_")
+        run_dir = run_sim(
+            SimConfig(
+                start=date(2022, 1, 3),
+                end=date(2022, 3, 31),
+                initial_cash=initial_cash,
+                data_dir=str(DATA_DIR),
+                broker=broker,
+            ),
+            mode="backtest",
+            run_base_dir=Path(td),
+        )
+        return run_dir
+
+    def test_lot_size_and_turnover_enforced(self) -> None:
+        run_dir = self._run(BrokerConfig(lot_size=10, max_daily_turnover=0.03))
+
+        with (run_dir / "fills.csv").open() as f:
+            fills = list(csv.DictReader(f))
+        for f in fills:
+            if f["side"].upper() == "BUY":
+                self.assertEqual(int(float(f["qty"])) % 10, 0)
+
+        with (run_dir / "orders.csv").open() as f:
+            orders = list(csv.DictReader(f))
+        self.assertTrue(any(o["reason"] == "rounded_lot" for o in orders))
+        self.assertTrue(any(o["reason"] == "blocked_turnover" for o in orders))
+
+        with (run_dir / "equity_curve.csv").open() as f:
+            eq = list(csv.DictReader(f))
+        nav_by_day = {r["day"]: float(r["nav"]) for r in eq}
+        days = [r["day"] for r in eq]
+        prev_nav = {days[i]: float(eq[i - 1]["nav"]) for i in range(1, len(days))}
+
+        buy_notional_by_day: dict[str, float] = {}
+        for f in fills:
+            if f["side"].upper() == "BUY":
+                buy_notional_by_day.setdefault(f["day"], 0.0)
+                buy_notional_by_day[f["day"]] += float(f["notional"])
+
+        for d, notional in buy_notional_by_day.items():
+            if d in prev_nav and prev_nav[d] > 0:
+                self.assertLessEqual(notional / prev_nav[d], 0.03 + 1e-9)
+
+    def test_gap_block_and_min_notional_reasons_traceable(self) -> None:
+        run_gap = self._run(BrokerConfig(gap_block_threshold=0.0))
+        with (run_gap / "orders.csv").open() as f:
+            orders_gap = list(csv.DictReader(f))
+        self.assertTrue(any(o["reason"] == "blocked_gap" for o in orders_gap))
+
+        run_min = self._run(BrokerConfig(min_trade_notional=1_000_000.0), initial_cash=50_000.0)
+        with (run_min / "orders.csv").open() as f:
+            orders_min = list(csv.DictReader(f))
+        self.assertTrue(any(o["reason"] == "below_min_notional" for o in orders_min))
+
+    def test_invalid_params_exit_code_2(self) -> None:
+        py = str(ROOT / ".venv" / "bin" / "python")
+        base = [py, "-m", "quant_proto", "backtest", "--start", "2022-01-03", "--end", "2022-03-31"]
+
+        cases = [
+            (["--lot-size", "0"], "lot_size"),
+            (["--max-daily-turnover", "-0.1"], "max_daily_turnover"),
+            (["--max-daily-turnover", "1.1"], "max_daily_turnover"),
+            (["--gap-block-threshold", "-0.1"], "gap_block_threshold"),
+        ]
+        for extra, key in cases:
+            p = subprocess.run(base + extra, cwd=str(ROOT), capture_output=True, text=True)
+            self.assertEqual(p.returncode, 2)
+            self.assertIn(key, (p.stderr or "").lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implement T1.4 execution constraints and trade guards for quant-proto.

### Added
- `min_trade_notional` gate
- `lot_size` rounding to share lots
- `max_daily_turnover` cap
- `gap_block_threshold` to block new BUY opens on large overnight gap
- Test coverage in `quant-proto/tests/test_execution_constraints.py`

## Validation
- Full tests in `quant-proto/.venv`: `7 passed`
- Smoke backtest (2024-01-01 ~ 2024-03-31):
  - Total Return: +5.07%
  - CAGR: 22.66%
  - Vol(ann): 6.86%
  - Sharpe: 3.0602
  - Max DD: 1.04%

Closes #2
